### PR TITLE
fix: broken link in README to CONTRIBUTING

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ I *smell* a rat...
 - 🪲 **Report a bug** — but with your _specialized technical diagnosis_!
 - 🫱 **Send some advice!** Not just a first-time Obsidian plugin dev, but my first public community project.
 
-> 💝 See [Contributing](/contributing.md) for proper technical details!
+> 💝 See [Contributing](/CONTRIBUTING.md) for proper technical details!
 
 ### 🤙 Contact
 


### PR DESCRIPTION
### Goal

Fix seemingly broken link in `README.md`.

### Test

1. Open https://github.com/wesleyboar/obsidian-fountain-editor/blob/patch-1/README.md.
2. Scroll to "See [Contributing](#) for proper technical details!"
3. Click "Contributing" link.
4. Verify document opens.

### Visual

| Before | After |
| - | - |
| <img width="954" alt="before" src="https://github.com/chuangcaleb/obsidian-fountain-editor/assets/62723358/aabe48dd-3c22-43e2-afdc-c660781c91e2"> | <img width="954" alt="after" src="https://github.com/chuangcaleb/obsidian-fountain-editor/assets/62723358/8a524c11-ba7a-4034-92ca-b761a13ab3ff"> |
