### PR TITLE
SUGGESTION: Add option for extended parsing range

### DIFF
--- a/src/editor/decorations.ts
+++ b/src/editor/decorations.ts
@@ -121,6 +121,12 @@ function getLineFormat(
 	return n.action;
 }
 
+// TODO: I didn't figure out how to do this properly
+let extraParseRange = 0;
+export function setExtraParseRange(range: number) {
+	extraParseRange = range;
+}
+
 export function buildDecorations(
 	view: EditorView,
 	isFountainStateField: StateField<boolean>,
@@ -144,7 +150,12 @@ export function buildDecorations(
 		inCommentBlock: false,
 	};
 
-	for (const {from, to} of view.visibleRanges) {
+	for (let {from, to} of view.visibleRanges) {
+
+		// Extend parse range
+		from = Math.max(from - extraParseRange, 0);
+		to = Math.min(to + extraParseRange, view.state.doc.length);
+
 		const visibleText = view.state.sliceDoc(from, to);
 		const maxLines = view.state.doc.lines;
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -47,7 +47,7 @@ export default class FountainPlugin extends Plugin {
 
 		// TODO: Pass the value to the view plugin better?
 		setExtraParseRange(this.settings.extraParseRange);
-	  }
+	}
 	
 	async saveSettings() {
 		await this.saveData(this.settings);

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,10 +2,25 @@ import {Prec} from "@codemirror/state";
 import {Plugin, type TFile} from "obsidian";
 import {fountainPlugin} from "./editor/plugin.js";
 import {onMetadataChanged, updateClass} from "./tracker.js";
+import {FountainSettingTab} from "./settingTab.js";
+import {setExtraParseRange} from "./editor/decorations.js";
+
+interface FountainPluginSettings {
+	extraParseRange: number;
+}
+
+const DEFAULT_SETTINGS: Partial<FountainPluginSettings> = {
+	extraParseRange: 0,
+};
 
 export default class FountainPlugin extends Plugin {
+	settings: FountainPluginSettings;
+
 	async onload() {
 		this.registerEditorExtension(Prec.lowest(fountainPlugin));
+		
+		await this.loadSettings();
+		this.addSettingTab(new FountainSettingTab(this.app, this));
 
 		// Ensure `fountain` class is added to relevant leaves
 		this.app.workspace.on("active-leaf-change", () => {
@@ -25,5 +40,19 @@ export default class FountainPlugin extends Plugin {
 			onMetadataChanged(this.app, file);
 		});
 		updateClass(this.app);
+	}
+
+	async loadSettings() {
+		this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());
+
+		// TODO: Pass the value to the view plugin better?
+		setExtraParseRange(this.settings.extraParseRange);
+	  }
+	
+	async saveSettings() {
+		await this.saveData(this.settings);
+
+		// TODO: Pass the value to the view plugin better?
+		setExtraParseRange(this.settings.extraParseRange);
 	}
 }

--- a/src/settingTab.ts
+++ b/src/settingTab.ts
@@ -2,31 +2,31 @@ import FountainPlugin from './main';
 import { App, PluginSettingTab, Setting } from 'obsidian';
 
 export class FountainSettingTab extends PluginSettingTab {
-  plugin: FountainPlugin;
+	plugin: FountainPlugin;
 
-  constructor(app: App, plugin: FountainPlugin) {
-    super(app, plugin);
-    this.plugin = plugin;
-  }
+	constructor(app: App, plugin: FountainPlugin) {
+		super(app, plugin);
+		this.plugin = plugin;
+	}
 
-  display(): void {
-    let { containerEl } = this;
+	display(): void {
+		let { containerEl } = this;
 
-    containerEl.empty();
+		containerEl.empty();
 
-    new Setting(this.containerEl)
-      .setName("Extra parsed characters")
-      .setDesc("Higher values may improve parsing stability at the expense of performance.")
-      .addText((textfield) => {
-        textfield.inputEl.type = "number";
-        textfield.setValue(String(this.plugin.settings.extraParseRange));
-        textfield.onChange(async (value) => {
-            let num = Number(value);
-            if (!Number.isNaN(num) && num >= 0) {
-                this.plugin.settings.extraParseRange = num;
-                await this.plugin.saveSettings();
-            }
-        });
-      });
-  }
+		new Setting(this.containerEl)
+			.setName("Extra parsed characters")
+			.setDesc("Higher values may improve parsing stability at the expense of performance.")
+			.addText((textfield) => {
+				textfield.inputEl.type = "number";
+				textfield.setValue(String(this.plugin.settings.extraParseRange));
+				textfield.onChange(async (value) => {
+					let num = Number(value);
+					if (!Number.isNaN(num) && num >= 0) {
+						this.plugin.settings.extraParseRange = num;
+						await this.plugin.saveSettings();
+					}
+				});
+			});
+	}
 }

--- a/src/settingTab.ts
+++ b/src/settingTab.ts
@@ -1,0 +1,32 @@
+import FountainPlugin from './main';
+import { App, PluginSettingTab, Setting } from 'obsidian';
+
+export class FountainSettingTab extends PluginSettingTab {
+  plugin: FountainPlugin;
+
+  constructor(app: App, plugin: FountainPlugin) {
+    super(app, plugin);
+    this.plugin = plugin;
+  }
+
+  display(): void {
+    let { containerEl } = this;
+
+    containerEl.empty();
+
+    new Setting(this.containerEl)
+      .setName("Extra parsed characters")
+      .setDesc("Higher values may improve parsing stability at the expense of performance.")
+      .addText((textfield) => {
+        textfield.inputEl.type = "number";
+        textfield.setValue(String(this.plugin.settings.extraParseRange));
+        textfield.onChange(async (value) => {
+            let num = Number(value);
+            if (!Number.isNaN(num) && num >= 0) {
+                this.plugin.settings.extraParseRange = num;
+                await this.plugin.saveSettings();
+            }
+        });
+      });
+  }
+}


### PR DESCRIPTION
Hi, great extension!

One immediate issue I've encountered is poor "parsing stability".
Here's my suggestion for a user defined extended parsing range.

https://github.com/user-attachments/assets/4fefb481-c61d-4382-a196-1966805a02c3

## Current issues

- I have no clue how to pass the setting to the view plugin properly. Maybe you'll know?
- Entering a number in the settings isn't intuitive
    - Maybe it should be a 0-100% added range slider?
    - Or a drop down with pre-defined low / medium / high ranges?

Let me know what you think. 🙏

It's pretty baffling there's not many fountain editors for windows. This extension is currently the best thing I found. Hope we can iron out the kinks and make it perfect.